### PR TITLE
Update day8.md

### DIFF
--- a/milestone2-analysis/day8.md
+++ b/milestone2-analysis/day8.md
@@ -192,7 +192,7 @@ In TS, the general pattern for checking subexpressions is this:
 
 In TS, you need to specify the types of operators in axioms:
 
-    Length(): (IntArray(), Int())
+    LengthOp(): (IntArray(), Int())
 
 Here, `e` should match an expression with subexpressions `e1` and `e2` and
 `ty` should be the type of `e`, while `ty1` and `ty2` should be the expected types of `e1` and `e2`, respectively.


### PR DESCRIPTION
The constructor name for the length function is LengthOp() not Length(). This is shown in the list below but the instruction could be confusing. I found this and confirmed with Peter van Buul
